### PR TITLE
After enable \r\n for old Foundry/Brocade devices

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -73,7 +73,7 @@ class IronWare < Oxidized::Model
   cfg :telnet, :ssh do
     if vars :enable
       post_login do
-        send "enable\r\n"
+        send "enable\n"
         send vars(:enable) + "\r\n"
       end
     end


### PR DESCRIPTION
\r\n for old Foundry/Brocade devices

Tested with:
Brocade XMR/MLXe netiron
Brocade FCX series
Brocader CER (also netiron)
Brocade/Foundry FESX424F (old device) <- not working after enable without patch
